### PR TITLE
[EI-4196] - Added suppressReadReceipt field in update method

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -672,6 +672,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    * @param messageDisposition                 the message disposition
    * @param sendInvitationsOrCancellationsMode the send invitations or cancellations mode
    * @param errorHandling                      the error handling
+   * @param suppressReadReceipts               the suppress read receipt status
    * @return A ServiceResponseCollection providing update results for each of
    * the specified item.
    * @throws Exception the exception
@@ -682,7 +683,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       ConflictResolutionMode conflictResolution,
       MessageDisposition messageDisposition,
       SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode,
-      ServiceErrorHandling errorHandling) throws Exception {
+      ServiceErrorHandling errorHandling,
+      boolean suppressReadReceipts) throws Exception {
     UpdateItemRequest request = new UpdateItemRequest(this, errorHandling);
 
     request.getItems().addAll((Collection<? extends Item>) items);
@@ -691,7 +693,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     request.setConflictResolutionMode(conflictResolution);
     request
         .setSendInvitationsOrCancellationsMode(sendInvitationsOrCancellationsMode);
-
+    request.setSuppressReadReceipts(suppressReadReceipts);
     return request.execute();
   }
 
@@ -704,6 +706,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    * @param conflictResolution                 the conflict resolution
    * @param messageDisposition                 the message disposition
    * @param sendInvitationsOrCancellationsMode the send invitations or cancellations mode
+   * @param suppressReadReceipt                the suppress read receipt status
    * @return A ServiceResponseCollection providing update results for each of
    * the specified item.
    * @throws Exception the exception
@@ -713,7 +716,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       FolderId savedItemsDestinationFolderId,
       ConflictResolutionMode conflictResolution,
       MessageDisposition messageDisposition,
-      SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode)
+      SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode,
+      boolean suppressReadReceipt)
       throws Exception {
 
     // All item have to exist on the server (!new) and modified (dirty)
@@ -741,7 +745,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
 
     return this.internalUpdateItems(items, savedItemsDestinationFolderId, conflictResolution,
                                     messageDisposition, sendInvitationsOrCancellationsMode,
-                                    ServiceErrorHandling.ReturnErrors);
+                                    ServiceErrorHandling.ReturnErrors, suppressReadReceipt);
   }
 
   /**
@@ -752,13 +756,15 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    * @param conflictResolution                 the conflict resolution
    * @param messageDisposition                 the message disposition
    * @param sendInvitationsOrCancellationsMode the send invitations or cancellations mode
+   * @param suppressReadReceipt                the suppress read receipt status
    * @return A ServiceResponseCollection providing deletion results for each
    * of the specified item Ids.
    * @throws Exception the exception
    */
   public Item updateItem(Item item, FolderId savedItemsDestinationFolderId,
       ConflictResolutionMode conflictResolution, MessageDisposition messageDisposition,
-      SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode)
+      SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode,
+      boolean suppressReadReceipt)
       throws Exception {
     List<Item> itemIdArray = new ArrayList<Item>();
     itemIdArray.add(item);
@@ -767,7 +773,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
         .internalUpdateItems(itemIdArray,
             savedItemsDestinationFolderId, conflictResolution,
             messageDisposition, sendInvitationsOrCancellationsMode,
-            ServiceErrorHandling.ThrowOnError);
+            ServiceErrorHandling.ThrowOnError,
+            suppressReadReceipt);
 
     return responses.getResponseAtIndex(0).getReturnedItem();
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/XmlAttributeNames.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/XmlAttributeNames.java
@@ -110,6 +110,11 @@ public class XmlAttributeNames {
   public static final String MessageDisposition = "MessageDisposition";
 
   /**
+   * The Constant SuppressReadReceipts.
+   */
+  public static final String SuppressReadReceipts = "SuppressReadReceipts";
+
+  /**
    * The Constant SaveItemToFolder.
    */
   public static final String SaveItemToFolder = "SaveItemToFolder";

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateItemRequest.java
@@ -77,6 +77,11 @@ public final class UpdateItemRequest extends
       sendInvitationsOrCancellationsMode;
 
   /**
+   * To suppress read receipt in email.
+   */
+  private boolean suppressReadReceipts;
+
+  /**
    * Instantiates a new update item request.
    *
    * @param service           the service
@@ -192,6 +197,10 @@ public final class UpdateItemRequest extends
 
     writer.writeAttributeValue(XmlAttributeNames.ConflictResolution,
         this.conflictResolutionMode);
+
+    if (this.suppressReadReceipts) {
+        writer.writeAttributeValue(XmlAttributeNames.SuppressReadReceipts, this.suppressReadReceipts);
+    }
 
     if (this.sendInvitationsOrCancellationsMode != null) {
       writer.writeAttributeValue(
@@ -321,4 +330,21 @@ public final class UpdateItemRequest extends
     this.savedItemsDestinationFolder = value;
   }
 
+  /**
+   * Gets the value of the suppress read receipt.
+   * @return the value of suppress read receipt.
+   */
+  public boolean isSuppressReadReceipts() {
+    return suppressReadReceipts;
+  }
+
+  /**
+   * Sets the suppress read receipt.
+   * @param suppressReadReceipt
+   */
+  public void setSuppressReadReceipts(boolean suppressReadReceipts) {
+    this.suppressReadReceipts = suppressReadReceipts;
+  }
+
+  
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Appointment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Appointment.java
@@ -411,15 +411,17 @@ public class Appointment extends Item implements ICalendarActionProvider {
    *
    * @param conflictResolutionMode             the conflict resolution mode
    * @param sendInvitationsOrCancellationsMode the send invitations or cancellations mode
+   * @param suppressReadReceipt                the suppress read receipt status
    * @throws Exception the exception
    */
   public void update(
       ConflictResolutionMode conflictResolutionMode,
       SendInvitationsOrCancellationsMode
-          sendInvitationsOrCancellationsMode)
+          sendInvitationsOrCancellationsMode,
+      boolean suppressReadReceipt)
       throws Exception {
     this.internalUpdate(null, conflictResolutionMode, null,
-        sendInvitationsOrCancellationsMode);
+        sendInvitationsOrCancellationsMode, suppressReadReceipt);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/EmailMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/EmailMessage.java
@@ -163,7 +163,7 @@ public class EmailMessage extends Item {
       if (this.getPropertyBag().getIsUpdateCallNecessary()) {
         this.internalUpdate(parentFolderId,
             ConflictResolutionMode.AutoResolve, messageDisposition,
-            null);
+            null, false);
       } else {
         this.getService().sendItem(this, parentFolderId);
       }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Item.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Item.java
@@ -260,6 +260,7 @@ public class Item extends ServiceObject {
    * @param conflictResolutionMode             the conflict resolution mode
    * @param messageDisposition                 the message disposition
    * @param sendInvitationsOrCancellationsMode the send invitations or cancellations mode
+   * @param suppressReadReceipt                the suppress read receipt status
    * @return Updated item.
    * @throws ServiceResponseException the service response exception
    * @throws Exception                the exception
@@ -268,7 +269,8 @@ public class Item extends ServiceObject {
       FolderId parentFolderId,
       ConflictResolutionMode conflictResolutionMode,
       MessageDisposition messageDisposition,
-      SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode)
+      SendInvitationsOrCancellationsMode sendInvitationsOrCancellationsMode,
+      boolean suppressReadReceipt)
       throws ServiceResponseException, Exception {
     this.throwIfThisIsNew();
     this.throwIfThisIsAttachment();
@@ -285,7 +287,8 @@ public class Item extends ServiceObject {
               messageDisposition,
               sendInvitationsOrCancellationsMode != null ? sendInvitationsOrCancellationsMode
                   : this
-                  .getDefaultSendInvitationsOrCancellationsMode());
+                  .getDefaultSendInvitationsOrCancellationsMode(),
+              suppressReadReceipt);
     }
     if (this.hasUnprocessedAttachmentChanges()) {
       // Validation of the item and its attachments occurs in
@@ -392,13 +395,14 @@ public class Item extends ServiceObject {
    * be made if attachments have been added or removed.
    *
    * @param conflictResolutionMode the conflict resolution mode
+   * @param suppressReadReceipt    the suppress read receipt status
    * @throws ServiceResponseException the service response exception
    * @throws Exception                the exception
    */
-  public void update(ConflictResolutionMode conflictResolutionMode)
+  public void update(ConflictResolutionMode conflictResolutionMode, boolean suppressReadReceipt)
       throws ServiceResponseException, Exception {
     this.internalUpdate(null /* parentFolder */, conflictResolutionMode,
-        MessageDisposition.SaveOnly, null);
+        MessageDisposition.SaveOnly, null, suppressReadReceipt);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Task.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Task.java
@@ -164,6 +164,7 @@ public class Task extends Item {
    * might be made if attachments have been added or removed.
    *
    * @param conflictResolutionMode the conflict resolution mode
+   * @param suppressReadReceipt suppress read receipt status
    * @return A Task object representing the completed occurrence if the task
    * is recurring and the update marks it as completed; or a Task
    * object representing the current occurrence if the task is
@@ -172,10 +173,10 @@ public class Task extends Item {
    * @throws ServiceResponseException the service response exception
    * @throws Exception                the exception
    */
-  public Task updateTask(ConflictResolutionMode conflictResolutionMode)
+  public Task updateTask(ConflictResolutionMode conflictResolutionMode, boolean suppressReadReceipt)
       throws ServiceResponseException, Exception {
     return (Task) this.internalUpdate(null /* parentFolder */,
-        conflictResolutionMode, MessageDisposition.SaveOnly, null);
+        conflictResolutionMode, MessageDisposition.SaveOnly, null, suppressReadReceipt);
   }
 
   // Properties


### PR DESCRIPTION
[EI-4196](https://perzoinc.atlassian.net/browse/EI-4196) - Added suppressReadReceipt field in update method

## Issue
- The issue in "read" email action. Currently, read email action is not working when an email is with a read receipt. It will automatically send the read receipt response mail to the sender.

## Approach
- Add suppress read receipt logic in the update method.

## Related PRs
- [email-integration-common](https://github.com/SymphonyOSF/email-integration-common/pull/459)
- [EmailService](https://github.com/SymphonyOSF/EmailService/pull/481)
- [Ingestor](https://github.com/SymphonyOSF/Ingestor/pull/438)