### PR TITLE
[EI-4177] Dead letter - emailProvider failed and no fallback available.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <groupId>com.microsoft.ews-java-api</groupId>
     <artifactId>ews-java-api</artifactId>
     
-    <version>2.2-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
 
     <name>Exchange Web Services Java API</name>
     <description>Exchange Web Services (EWS) Java API</description>
@@ -213,6 +213,16 @@
     </distributionManagement>
 
     <dependencies>
+    	<dependency>
+            <groupId>com.github.rwitzel.streamflyer</groupId>
+            <artifactId>streamflyer-core</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.parsers</groupId>
+            <artifactId>jaxp-ri</artifactId>
+            <version>1.4.5</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
@@ -32,6 +32,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.sun.org.apache.xerces.internal.impl.Constants;
+import com.sun.org.apache.xerces.internal.impl.XMLErrorReporter;
+import com.sun.xml.internal.stream.XMLInputFactoryImpl;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -96,10 +100,16 @@ public class EwsXmlReader {
    * @throws Exception on error
    */
   protected XMLEventReader initializeXmlReader(InputStream stream) throws Exception {
-    XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+    XMLInputFactory inputFactory = new XMLInputFactoryImpl();
     inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
 
-    return inputFactory.createXMLEventReader(stream);
+    XMLEventReader reader = inputFactory.createXMLEventReader(stream);
+
+    XMLErrorReporter errorReporter = (XMLErrorReporter) reader
+        .getProperty(Constants.XERCES_PROPERTY_PREFIX + Constants.ERROR_REPORTER_PROPERTY);
+
+    errorReporter.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.CONTINUE_AFTER_FATAL_ERROR_FEATURE, true);
+    return reader;
   }
 
 


### PR DESCRIPTION
## Descritption
[EI-4177] Dead letter - email provider failed and no fallback available.

## Issue
Email not ingest due to control character in email.
"Caused by: javax.xml.stream.XMLStreamException: ParseError at Message: Character reference ""&# ".

## Approach
Now we are replacing the control characters in the subject & snippet. Convert the control character hex to decimal and then ingest to POD.

[EI-4177]: https://perzoinc.atlassian.net/browse/EI-4177

## Related PRs
[comment]: # (List the related PRs against other branches.)
Repo | Branch | PR #
------ | ------ | ------
email-integration-common | EI-4177 | [PR 520](https://github.com/SymphonyOSF/email-integration-common/pull/520)